### PR TITLE
Feat/abstract signup and join poll

### DIFF
--- a/plugins/maciVoting/components/MaciCard.tsx
+++ b/plugins/maciVoting/components/MaciCard.tsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useMaci } from "../hooks/useMaci";
 
 const MaciCard = () => {
-  const { onSignup, maciKeypair, isRegistered, isLoading, createKeypair, deleteKeypair, error: maciError } = useMaci();
+  const { onSignup, maciKeypair, isRegistered, isLoading, deleteKeypair, error: maciError } = useMaci();
   const [error, setError] = useState<string | undefined>(undefined);
 
   useEffect(() => {
@@ -17,19 +17,12 @@ const MaciCard = () => {
     if (isRegistered) {
       return "Already signed up";
     }
-    if (!maciKeypair) {
-      return "Generate keys";
-    }
     return "Sign up";
-  }, [maciKeypair, isRegistered, isLoading]);
+  }, [isRegistered, isLoading]);
 
   const onClick = useCallback(async () => {
-    if (!maciKeypair) {
-      await createKeypair();
-    } else {
-      await onSignup();
-    }
-  }, [createKeypair, maciKeypair, onSignup]);
+    await onSignup();
+  }, [onSignup]);
 
   return (
     <Card className="flex flex-col gap-y-4 p-6 shadow-neutral">

--- a/plugins/maciVoting/contexts/types.ts
+++ b/plugins/maciVoting/contexts/types.ts
@@ -32,7 +32,6 @@ export interface IMaciContextType {
   isRegistered?: boolean;
   maciKeypair?: Keypair;
   stateIndex?: string;
-  createKeypair: () => Promise<Keypair | undefined>;
   deleteKeypair: () => void;
   onSignup: () => Promise<void>;
   onJoinPoll: (pollId: bigint) => Promise<void>;


### PR DESCRIPTION
This PR doesn't really abstract signup AND join poll. But based on discussion the other day, we decided to keep joining maci and joining poll both as explicit separate actions. We did decide that we wanted to abstract key generation and joining maci into one action. So now a user just needs to click sign up, then a key will be generated and they will join maci in one step